### PR TITLE
Fixed compilation error

### DIFF
--- a/examplecode/tasks.d
+++ b/examplecode/tasks.d
@@ -27,4 +27,3 @@ void main() {
         std.algorithm.map!getTerm(iota(n))
     );
 }
- 

--- a/examplecode/tasks.d
+++ b/examplecode/tasks.d
@@ -1,5 +1,14 @@
 import std.algorithm, std.parallelism, std.range;
 
+immutable n = 1_000_000_000;
+immutable delta = 1.0 / n;
+
+real getTerm(int i)
+{
+	immutable x = ( i - 0.5 ) * delta;
+	return delta / ( 1.0 + x * x ) ;
+}
+
 void main() {
     // Parallel reduce can be combined with
     // std.algorithm.map to interesting effect.
@@ -14,17 +23,8 @@ void main() {
     // TaskPool.reduce:       12.170 s
     // std.algorithm.reduce:  24.065 s
 
-    immutable n = 1_000_000_000;
-    immutable delta = 1.0 / n;
-
-    real getTerm(int i)
-    {
-        immutable x = ( i - 0.5 ) * delta;
-        return delta / ( 1.0 + x * x ) ;
-    }
-
     immutable pi = 4.0 * taskPool.reduce!"a + b"(
         std.algorithm.map!getTerm(iota(n))
     );
 }
-
+ 


### PR DESCRIPTION
This example doesn't compile anymore in more recent versions of dmd (I'm using v2.073.2). Moving the getTerm function outside main makes it work. 

Relevant thread: http://forum.dlang.org/post/fhmyuhtwqwznoyahlxva@forum.dlang.org